### PR TITLE
Feature: Add pagination to department listing

### DIFF
--- a/app/Http/Controllers/DepartmentController.php
+++ b/app/Http/Controllers/DepartmentController.php
@@ -12,7 +12,8 @@ class DepartmentController extends Controller
     {
         $departments = Department::with('college')
             ->where('is_active', true)
-            ->get();
+            ->paginate(10); // Changed from ->get() to ->paginate(10)
+    
         return view('departments.index', compact('departments'));
     }
 

--- a/resources/views/departments/index.blade.php
+++ b/resources/views/departments/index.blade.php
@@ -8,6 +8,10 @@
     <a href="{{ route('departments.create') }}" class="btn btn-primary">Add New Department</a>
 </div>
 
+<div class="d-flex justify-content-center mt-4">
+    {{ $departments->links() }}
+</div>
+
 <div class="card">
     <div class="card-body">
         <table class="table table-bordered table-striped">


### PR DESCRIPTION
This PR adds pagination to the department listing page to improve performance and user experience when dealing with large numbers of departments.

Changes:
- Modified DepartmentController to use paginate() instead of get()
- Added pagination links to the departments index view
- Set pagination to 10 items per page

Closes #5